### PR TITLE
Alteração do parâmetro semestre_vinculo para semestre_ingresso nas queries SQL

### DIFF
--- a/models/Curso.py
+++ b/models/Curso.py
@@ -135,7 +135,7 @@ class Curso():
   ## Computação e suas estatísticas de todos os períodos.
   def get_graduates(self, args):
 
-    base_query = 'SELECT semestre_vinculo, count(*) AS qtd_egressos, avg(cra) AS cra_medio \
+    base_query = 'SELECT semestre_ingresso, count(*) AS qtd_egressos, avg(cra) AS cra_medio \
       FROM "DiscenteVinculo" \
       INNER JOIN "Discente" \
         ON "DiscenteVinculo".cpf = "Discente".cpf \
@@ -147,16 +147,16 @@ class Curso():
     if (len(args) == 1):
       periodo = args.get('de')
 
-      base_query += 'AND semestre_vinculo=\'' + str(periodo) + '\' \
-        GROUP BY semestre_vinculo \
-        ORDER BY semestre_vinculo'
+      base_query += 'AND semestre_ingresso=\'' + str(periodo) + '\' \
+        GROUP BY semestre_ingresso \
+        ORDER BY semestre_ingresso'
 
       result = self.connection.select(base_query)
 
       # Caso não hajam registros que correspondam a query passada.
       if (len(result) == 0):
         return { 
-          "semestre_vinculo": periodo, 
+          "semestre_ingresso": periodo, 
           "qtd_egressos": 0,
           "cra_medio": 0 
         }
@@ -175,15 +175,15 @@ class Curso():
       if (minimo > maximo or minimo == maximo):
         return { "error": "Parameters or invalid request" }, 404
 
-      base_query += 'AND semestre_vinculo BETWEEN \'' + str(minimo) + '\' AND \'' + str(maximo) + '\'\
-        GROUP BY semestre_vinculo\
-        ORDER BY semestre_vinculo'
+      base_query += 'AND semestre_ingresso BETWEEN \'' + str(minimo) + '\' AND \'' + str(maximo) + '\'\
+        GROUP BY semestre_ingresso \
+        ORDER BY semestre_ingresso'
 
     # Para rotas do tipo '.../api/estatisticas/egressos', que retornam o número de egressos de
     ## todos os períodos até então cadastrados.
     else:
-      base_query += 'GROUP BY semestre_vinculo \
-        ORDER BY semestre_vinculo'
+      base_query += 'GROUP BY semestre_ingresso \
+        ORDER BY semestre_ingresso'
 
     result = self.connection.select(base_query)
     statistics = get_statistics(result)
@@ -207,9 +207,9 @@ class Curso():
     # Query base que trás as informações que são comuns às rotas que possuem parâmetros,
     ## e para cada parâmetro, a condição específica é adicionada a essa string de consulta
     ### base.
-    base_query = 'SELECT matricula, per_int, cred_obrig_int, cred_opt_int, cred_comp_int, \
-      "Cota".descricao, "Genero".descricao, "EstadoCivil".descricao, curriculo, cra, \
-      mc, iea, tranc, mat_inst, mob_estudantil, media_geral_ingresso \
+    base_query = 'SELECT matricula, semestre_ingresso, per_int, cred_obrig_int, \
+      cred_opt_int, cred_comp_int, "Cota".descricao, "Genero".descricao, "EstadoCivil".descricao, \
+      curriculo, cra, mc, iea, tranc, mat_inst, mob_estudantil, media_geral_ingresso \
       FROM "Discente" \
       INNER JOIN "DiscenteVinculo" \
         ON "Discente".cpf = "DiscenteVinculo".cpf \
@@ -225,7 +225,7 @@ class Curso():
     if (len(args) == 1):
       periodo = args.get('de')
 
-      base_query += 'AND semestre_vinculo=\'' + str(periodo) + '\' \
+      base_query += 'AND semestre_ingresso=\'' + str(periodo) + '\' \
       ORDER BY semestre_ingresso'
 
     elif (len(args) == 2):
@@ -237,7 +237,7 @@ class Curso():
       if (minimo > maximo or minimo == maximo):
         return { "error": "Parameters or invalid request" }, 404
 
-      base_query += 'AND semestre_vinculo BETWEEN \'' + str(minimo) + '\' AND \'' + str(maximo) + '\'\
+      base_query += 'AND semestre_ingresso BETWEEN \'' + str(minimo) + '\' AND \'' + str(maximo) + '\'\
         ORDER BY semestre_ingresso'
 
     else:
@@ -330,10 +330,10 @@ class Curso():
     # Query base que trás as informações que são comuns às rotas que possuem parâmetros,
     ## e para cada parâmetro, a condição específica é adicionada a essa string de consulta
     ### base.
-    base_query = 'SELECT matricula, "SituacaoVinculo".descricao, per_int, cred_obrig_int, \
-      cred_opt_int, cred_comp_int, "Cota".descricao, "Genero".descricao, \
-      "EstadoCivil".descricao, curriculo, cra, mc, iea, tranc, mat_inst, \
-      mob_estudantil, media_geral_ingresso \
+    base_query = 'SELECT matricula, semestre_ingresso, "SituacaoVinculo".descricao, \
+      per_int, cred_obrig_int, cred_opt_int, cred_comp_int, "Cota".descricao, \
+      "Genero".descricao, "EstadoCivil".descricao, curriculo, cra, mc, iea, tranc, \
+      mat_inst, mob_estudantil, media_geral_ingresso \
       FROM "DiscenteVinculo" \
       INNER JOIN "Discente" \
         ON "DiscenteVinculo".cpf = "Discente".cpf \
@@ -353,7 +353,7 @@ class Curso():
     if (len(args) == 1):
       periodo = args.get('de')
 
-      base_query += 'AND semestre_vinculo=\'' + str(periodo) + '\' \
+      base_query += 'AND semestre_ingresso=\'' + str(periodo) + '\' \
         ORDER BY id_situacao_vinculo' 
     
     elif (len(args) == 2):
@@ -365,12 +365,13 @@ class Curso():
       if (minimo > maximo or minimo == maximo):
         return { "error": "Parameters or invalid request" }, 404
 
-      base_query += 'AND semestre_vinculo BETWEEN \'' + str(minimo) + '\' AND \'' + str(maximo) + '\'\
-        ORDER BY id_situacao_vinculo' 
+      base_query += 'AND semestre_ingresso BETWEEN \'' + str(minimo) + '\' AND \'' + str(maximo) + '\'\
+        ORDER BY semestre_ingresso' 
     
     else:
-      base_query += 'ORDER BY id_situacao_vinculo'
+      base_query += 'ORDER BY semestre_ingresso'
 
     result = self.connection.select(base_query)
+    print (len(result))
     return response_json_to_csv_escaped_export(result)
     

--- a/models/Curso.py
+++ b/models/Curso.py
@@ -52,7 +52,9 @@ class Curso():
   ## informações estas que são a matrícula do aluno e a cred_comp_int concluída do 
   ### curso com base na quantidade de créditos que o aluno já possui.
   def get_actives(self, args):
-    base_query = 'SELECT "DiscenteVinculo".matricula, "Discente".per_int, "Discente".cred_obrig_int, "Discente".cred_opt_int, "Discente".cred_comp_int \
+    base_query = 'SELECT "DiscenteVinculo".matricula, "Discente".per_int, \
+      "Discente".cred_obrig_int, "Discente".cred_opt_int, "Discente".cred_comp_int, \
+      "Discente".semestre_ingresso \
       FROM "DiscenteVinculo" \
       INNER JOIN "Discente" \
         ON "DiscenteVinculo".cpf = "Discente".cpf \
@@ -75,17 +77,11 @@ class Curso():
       if (minimo > maximo or minimo == maximo):
         return { "error": "Parameters or invalid request" }, 404
 
-      base_query += 'AND semestre_ingresso BETWEEN \'' + str(minimo) + '\' AND \'' + str(maximo) + '\''
+      base_query += 'AND semestre_ingresso BETWEEN \'' + str(minimo) + '\' AND \'' + str(maximo) + '\' \
+        ORDER BY semestre_ingresso'
 
     else:
-      base_query = 'SELECT "DiscenteVinculo".matricula, "Discente".per_int, "Discente".cred_obrig_int, "Discente".cred_opt_int, "Discente".cred_comp_int \
-        FROM "DiscenteVinculo"\
-        INNER JOIN "Discente"\
-          ON "DiscenteVinculo".cpf="Discente".cpf\
-        WHERE "DiscenteVinculo".id_curso=' + self.id_computacao + '\
-        AND "Discente".id_situacao=' + self.id_ativo + '\
-        AND "DiscenteVinculo".id_situacao_vinculo=' + self.id_regular + '\
-        AND "Discente".per_int > 0'
+      base_query += 'ORDER BY semestre_ingresso'
 
     result = self.connection.select(base_query)
     return response_json_to_active_route(result)
@@ -94,10 +90,10 @@ class Curso():
   # Função que retorna os dados para geração do arquivo csv de alunos ativos.
   def export_to_csv_actives(self, args):
 
-    base_query = 'SELECT "DiscenteVinculo".matricula, per_int, cred_obrig_int, cred_opt_int, \
-      cred_comp_int, "Cota".descricao, "Genero".descricao, "EstadoCivil".descricao, \
-      "Discente".curriculo, cra, mc, iea, tranc, mat_inst, mob_estudantil, \
-      media_geral_ingresso \
+    base_query = 'SELECT "DiscenteVinculo".matricula, semestre_ingresso, per_int, \
+      cred_obrig_int, cred_opt_int, cred_comp_int, "Cota".descricao, "Genero".descricao, \
+      "EstadoCivil".descricao, "Discente".curriculo, cra, mc, iea, tranc, mat_inst, \
+      mob_estudantil, media_geral_ingresso \
       FROM "DiscenteVinculo" \
       INNER JOIN "Discente" \
         ON "DiscenteVinculo".cpf = "Discente".cpf \
@@ -109,12 +105,13 @@ class Curso():
         ON "Discente".id_estado_civil = "EstadoCivil".id \
       WHERE "DiscenteVinculo".id_curso = ' + self.id_computacao + '\
       AND "Discente".id_situacao = ' + self.id_ativo + '\
+      AND "DiscenteVinculo".id_situacao_vinculo = ' + self.id_regular + ' \
       AND "Discente".per_int > 0'
 
     if (len(args) == 1):
       periodo = args.get('de')
 
-      base_query += 'AND "DiscenteVinculo".semestre_vinculo=\'' + str(periodo) + '\''
+      base_query += 'AND semestre_ingresso=\'' + str(periodo) + '\''
 
     elif (len(args) == 2):
       minimo = args.get('de')
@@ -125,7 +122,11 @@ class Curso():
       if (minimo > maximo or minimo == maximo):
         return { "error": "Parameters or invalid request" }, 404
       
-      base_query += 'AND semestre_vinculo BETWEEN \'' + str(minimo) + '\' AND \'' + str(maximo) + '\''
+      base_query += 'AND semestre_ingresso BETWEEN \'' + str(minimo) + '\' AND \'' + str(maximo) + '\' \
+        ORDER BY semestre_ingresso'
+    
+    else:
+      base_query += 'ORDER BY semestre_ingresso'
 
     result = self.connection.select(base_query)
     return response_json_to_csv_export(result)

--- a/models/util/StatisticsExternalFunctions.py
+++ b/models/util/StatisticsExternalFunctions.py
@@ -57,29 +57,24 @@ def response_json_to_csv_export(dados):
   json_return = []
   
   for registro in dados:
-    ano_ingresso = registro[0][1:3]
-    semestre_ingresso = registro[0][3]
-
-    periodo_ingresso = ano_ingresso + "." + semestre_ingresso
-
     json_return.append({
       "matricula": registro[0],
-      "periodo_ingresso": periodo_ingresso,
-      "periodos_integralizados": registro[1],
-      "cred_obrig_int": registro[2],
-      "cred_opt_int": registro[3],
-      "cred_comp_int": registro[4],
-      "cota": registro[5],
-      "genero": registro[6],
-      "estado_civil": registro[7],
-      "curriculo": registro[8],
-      "cra": registro[9],
-      "mc": registro[10],
-      "iea": registro[11],
-      "trancamentos_totais": registro[12],
-      "matriculas_institucionais": registro[13],
-      "mobilidade_estudantil": registro[14],
-      "media_geral_ingresso": registro[15]
+      "periodo_ingresso": registro[1],
+      "periodos_integralizados": registro[2],
+      "cred_obrig_int": registro[3],
+      "cred_opt_int": registro[4],
+      "cred_comp_int": registro[5],
+      "cota": registro[6],
+      "genero": registro[7],
+      "estado_civil": registro[8],
+      "curriculo": registro[9],
+      "cra": registro[10],
+      "mc": registro[11],
+      "iea": registro[12],
+      "trancamentos_totais": registro[13],
+      "matriculas_institucionais": registro[14],
+      "mobilidade_estudantil": registro[15],
+      "media_geral_ingresso": registro[16]
     })
   
   return jsonify(json_return)
@@ -91,30 +86,25 @@ def response_json_to_csv_escaped_export(dados):
   json_return = []
   
   for registro in dados:
-    ano_ingresso = registro[0][1:3]
-    semestre_ingresso = registro[0][3]
-
-    periodo_ingresso = ano_ingresso + "." + semestre_ingresso
-
     json_return.append({
       "matricula": registro[0],
-      "periodo_ingresso": periodo_ingresso,
-      "motivo_evasao": registro[1],
-      "periodos_integralizados": registro[2],
-      "cred_obrig_int": registro[3],
-      "cred_opt_int": registro[4],
-      "cred_comp_int": registro[5],
-      "cota": registro[6],
-      "genero": registro[7],
-      "estado_civil": registro[8],
-      "curriculo": registro[8],
-      "cra": registro[10],
-      "mc": registro[11],
-      "iea": registro[12],
-      "trancamentos_totais": registro[13],
-      "matriculas_institucionais": registro[14],
-      "mobilidade_estudantil": registro[15],
-      "media_geral_ingresso": registro[16]
+      "periodo_ingresso": registro[1],
+      "motivo_evasao": registro[2],
+      "periodos_integralizados": registro[3],
+      "cred_obrig_int": registro[4],
+      "cred_opt_int": registro[5],
+      "cred_comp_int": registro[6],
+      "cota": registro[7],
+      "genero": registro[8],
+      "estado_civil": registro[9],
+      "curriculo": registro[10],
+      "cra": registro[11],
+      "mc": registro[12],
+      "iea": registro[13],
+      "trancamentos_totais": registro[14],
+      "matriculas_institucionais": registro[15],
+      "mobilidade_estudantil": registro[16],
+      "media_geral_ingresso": registro[17]
     })
   
   return jsonify(json_return)
@@ -170,13 +160,15 @@ def response_json_to_graduates_route(periods):
 ## de cancelamento da matrícula) de um único período passado.
 def process_query_of_one_period(id_curso, id, periodo):
 
-  query = 'SELECT semestre_vinculo, count(*) AS qtd_evadidos\
-    FROM "DiscenteVinculo"\
-    WHERE id_curso=' + id_curso + \
-    ' AND id_situacao_vinculo=' + str(id) + '\
-    AND semestre_vinculo=\'' + str(periodo) + '\'\
-    GROUP BY semestre_vinculo\
-    ORDER BY semestre_vinculo'
+  query = 'SELECT semestre_ingresso, count(*) AS qtd_evadidos \
+    FROM "DiscenteVinculo" \
+    INNER JOIN "Discente" \
+      ON "DiscenteVinculo".cpf = "Discente".cpf \
+    WHERE id_curso=' + id_curso + ' \
+    AND id_situacao_vinculo=' + str(id) + ' \
+    AND semestre_ingresso=\'' + str(periodo) + '\' \
+    GROUP BY semestre_ingresso \
+    ORDER BY semestre_ingresso'
 
   result = connection.select(query)
   
@@ -191,13 +183,15 @@ def process_query_of_one_period(id_curso, id, periodo):
 ## de cancelamento da matrícula) de um intervalo de períodos passados.
 def process_query_of_interval_of_the_periods(id_curso, id, minimo, maximo):
 
-  query = 'SELECT semestre_vinculo, count(*) AS qtd_egressos\
-    FROM "DiscenteVinculo"\
+  query = 'SELECT semestre_ingresso, count(*) AS qtd_egressos \
+    FROM "DiscenteVinculo" \
+    INNER JOIN "Discente" \
+    ON "DiscenteVinculo".cpf = "Discente".cpf \
     WHERE id_curso=' + id_curso + \
     'AND id_situacao_vinculo=' + str(id) + \
-    'AND semestre_vinculo BETWEEN \'' + str(minimo) + '\' AND \'' + str(maximo) + '\'\
-    GROUP BY semestre_vinculo\
-    ORDER BY semestre_vinculo'
+    'AND semestre_ingresso BETWEEN \'' + str(minimo) + '\' AND \'' + str(maximo) + '\' \
+    GROUP BY semestre_ingresso \
+    ORDER BY semestre_ingresso'
 
   result = connection.select(query)
   
@@ -212,12 +206,14 @@ def process_query_of_interval_of_the_periods(id_curso, id, minimo, maximo):
 ## de cancelamento da matrícula, de todos os períodos registrados.
 def process_query_of_escaped(id_curso, id):
 
-  query = 'SELECT semestre_vinculo, count(*) AS qtd_evadidos\
-    FROM "DiscenteVinculo"\
-    WHERE id_curso=' + id_curso + \
-    ' AND id_situacao_vinculo=' + str(id) + '\
-    GROUP BY semestre_vinculo\
-    ORDER BY semestre_vinculo'
+  query = 'SELECT semestre_ingresso, count(*) AS qtd_evadidos \
+    FROM "DiscenteVinculo" \
+    INNER JOIN "Discente" \
+      ON "DiscenteVinculo".cpf = "Discente".cpf \
+    WHERE id_curso=' + id_curso + '\
+    AND id_situacao_vinculo=' + str(id) + '\
+    GROUP BY semestre_ingresso \
+    ORDER BY semestre_ingresso'
 
   result = connection.select(query)
   

--- a/models/util/StatisticsExternalFunctions.py
+++ b/models/util/StatisticsExternalFunctions.py
@@ -18,15 +18,10 @@ def response_json_to_active_route(dados):
     cred_comp_int = int(registro[4])
 
     cred_comp_int = get_percent(cred_obrig_int, cred_opt_int, cred_comp_int)
-
-    ano_ingresso = registro[0][1:3]
-    semestre_ingresso = registro[0][3]
-
-    periodo_ingresso = ano_ingresso + "." + semestre_ingresso
     
     json_return.append({ 
       "matricula": registro[0], 
-      "periodo_ingresso": periodo_ingresso,
+      "periodo_ingresso": registro[5],
       "periodos_integralizados": periodos_integralizados, 
       "porcentagem_concluida": round(cred_comp_int, 2)
     })
@@ -148,7 +143,7 @@ def response_json_to_graduates_route(periods):
   response = []
   for i in range(len(periods)):
     response.append({
-      "semestre_vinculo": periods[i][0], 
+      "semestre_ingresso": periods[i][0], 
       "qtd_egressos": periods[i][1],
       "cra_medio": round(periods[i][2], 2),
     })


### PR DESCRIPTION
Agora os semestres passados nos parâmetros 'de' e 'ate' das rotas são utilizados na query a partir do parâmetro semestre_ingresso de Discente, e não do semestre_vinculo de DiscenteVinculo, como era anteriormente.