### PR TITLE
Preenchendo a resposta json de evadidos com os períodos que não possuem evadidos

### DIFF
--- a/models/Curso.py
+++ b/models/Curso.py
@@ -10,7 +10,7 @@ from StatisticsExternalFunctions import (response_json_to_active_route, get_perc
   response_json_to_csv_export, get_statistics, response_json_to_graduates_route,
   process_query_of_one_period, join_results_of_escaped_query, fill_tag_list_with_zeros,
   response_json_to_escaped_route, process_query_of_escaped, process_query_of_interval_of_the_periods,
-  response_json_to_csv_escaped_export)
+  response_json_to_csv_escaped_export, add_periods_without_escaped)
 
 class Curso():
 
@@ -288,7 +288,7 @@ class Curso():
 
       # Caso o periodo minimo do intervalo seja maior que o maximo ou então igual, retorna
       ## uma mensagem de erro com código 404 not found.
-      if (minimo > maximo or minimo == maximo):
+      if (minimo > maximo):
         return { "error": "Parameters or invalid request" }, 404
 
       evadidos_por_motivo = []
@@ -297,8 +297,10 @@ class Curso():
           evadidos_por_motivo.append(process_query_of_interval_of_the_periods(self.id_computacao, i, minimo, maximo))
 
       joined_results = join_results_of_escaped_query(evadidos_por_motivo)
-      
-      joined_results_with_zeros = fill_tag_list_with_zeros(joined_results)
+
+      joined_results_all = add_periods_without_escaped(periodo_min=minimo, periodo_max=maximo, dados=joined_results)
+
+      joined_results_with_zeros = fill_tag_list_with_zeros(joined_results_all)
 
       json_return = response_json_to_escaped_route(joined_results_with_zeros)
 
@@ -316,7 +318,9 @@ class Curso():
 
       joined_results = join_results_of_escaped_query(evadidos_por_motivo)
 
-      joined_results_with_zeros = fill_tag_list_with_zeros(joined_results)
+      joined_results_all = add_periods_without_escaped(dados=joined_results)
+
+      joined_results_with_zeros = fill_tag_list_with_zeros(joined_results_all)
 
       json_return = response_json_to_escaped_route(joined_results_with_zeros)
 
@@ -373,6 +377,5 @@ class Curso():
       base_query += 'ORDER BY semestre_ingresso'
 
     result = self.connection.select(base_query)
-    print (len(result))
     return response_json_to_csv_escaped_export(result)
     

--- a/models/util/StatisticsExternalFunctions.py
+++ b/models/util/StatisticsExternalFunctions.py
@@ -241,6 +241,29 @@ def join_results_of_escaped_query(results):
   return dic_periodos
 
 
+# Função responsável por adicionar a resposta json os períodos do intervalo que não possui
+## alunos evadidos de nenhum dos tipos. periodo_min e max têm valores padrão para o caso de
+### a função ser chamadas sem os parâmetros 'de' e 'ate', ou seja, todo o intervalo.
+def add_periods_without_escaped(periodo_min='1987.1', periodo_max='2020.1', *, dados):
+  ano_ini = int(periodo_min[:4])
+  ano_fim = int(periodo_max[:4])
+  semestre_ini = int(periodo_min[5])
+  semestre_fim = int(periodo_max[5])
+
+  for ano in range(ano_ini, ano_fim+1):
+    for semestre in range(1, 3):
+      if (ano == ano_fim and semestre > semestre_fim):
+        pass
+      elif (ano == ano_ini and semestre < semestre_ini):
+        pass
+      else:
+        periodo = str(ano) + '.' + str(semestre)
+        if (periodo not in dados):
+          dados[str(ano)+'.'+str(semestre)] = {}
+    
+  return dados
+
+
 # Preenchendo com 0 as tags que não existem no objeto de cada período. Exemplo: caso o
 ## período X só tenha evadidos em "tag1", "tag2" e "tag3", o trecho abaixo irá preencher
 ### o objeto com o restante das tags até a 9 e também a 13, todas com o valor 0.    


### PR DESCRIPTION
Agora a resposta json das rotas de evadidos também trazem os períodos do intervalo que não possuem evadidos com os valores setados em zero.