### PR TITLE
Métricas class_statistics e success_overview implementadas.

### DIFF
--- a/models/Disciplina.py
+++ b/models/Disciplina.py
@@ -299,13 +299,6 @@ class Disciplina():
     )
 
 
-  def get_metrics(self, args):
-    metric_value = args.get('metric')
-
-    if (metric_value == 'class_overview'):
-      result = self.get_class_overview(args) 
-      return result
-
-    elif (metric_value == 'class_statistics'):
-      result = self.get_class_overview(args)
-      return result
+  def get_metrics(self, args):      
+    result = self.get_class_overview(args) 
+    return result

--- a/models/Disciplina.py
+++ b/models/Disciplina.py
@@ -221,6 +221,7 @@ class Disciplina():
   ## o número de alunos por turma e por período, além do código do professor que a leciona.
   def get_class_overview(self, args):
     subject_code = args.get('subject')
+    metric = args.get('metric')
 
     turmas_query = 'SELECT "Turma".periodo, "DiscenteDisciplina".id_turma, \
         COUNT("DiscenteDisciplina".*), "TurmaProfessor".siape \
@@ -272,24 +273,39 @@ class Disciplina():
         dic_disciplinas[result[i][0]]["students"].append(result[i][2])
         dic_disciplinas[result[i][0]]["teachers"].append(result[i][3])
 
-    classes = []
-    for i in dic_disciplinas:
-      classes.append({
-        "period": i,
-        "total": sum(dic_disciplinas[i]["students"]),
-        "teachers": dic_disciplinas[i]["teachers"],
-        "students": dic_disciplinas[i]["students"]
-      })
+    if (metric == 'class_overview'):
+      classes = []
+      for i in dic_disciplinas:
+        classes.append({
+          "period": i,
+          "total": sum(dic_disciplinas[i]["students"]),
+          "teachers": dic_disciplinas[i]["teachers"],
+          "students": dic_disciplinas[i]["students"]
+        })
+    
+    elif (metric == 'class_statistics'):
+      classes = []
+      for i in dic_disciplinas:
+        classes.append({
+          "period": i,
+          "minimum": min(dic_disciplinas[i]["students"]),
+          "maximum": max(dic_disciplinas[i]["students"]),
+          "average": round(sum(dic_disciplinas[i]["students"]) / len(dic_disciplinas[i]["students"]), 2)
+        })
 
     return jsonify(
       subject_code=subject_code,
       classes=classes
     )
-  
+
 
   def get_metrics(self, args):
     metric_value = args.get('metric')
 
     if (metric_value == 'class_overview'):
       result = self.get_class_overview(args) 
+      return result
+
+    elif (metric_value == 'class_statistics'):
+      result = self.get_class_overview(args)
       return result


### PR DESCRIPTION
A métrica class_statistics pode ser acessada através da rota:
/api/statistics/subjects/metrics?**subject**=1411167&**metric**=class_statistics
Ela retorna informações sobre o número de alunos na menor turma, maior turma e a média de alunos naquela disciplina naquele período (também podem ser usados os filtros 'from' e 'to' para seleção de um intervalo de períodos). A resposta json possui o formato a seguir:

{
  "classes": [
    {
      "average": 20.0,
      "maximum": 28,
      "minimum": 12,
      "period": "2002.1"
    },
    {...},
    {...},
    ]
  "subject_code": "1411167"
}

Já a métrica success_overview pode ser acessada através da rota:
/api/statistics/subjects/metrics?**subject**=1411167&**metric**=success_overview
Ela retorna as taxas de sucesso (nº de aprovados da turma / nº total de alunos da turma) de cada uma das turmas de cada um dos períodos do intervalo especificado (também podem ser usados os filtros 'from' e 'to' para seleção de um intervalo de períodos), além dos professores de cada uma das turmas e o total das taxas de sucesso, que nada mais é que a soma das taxas de um período. A resposta json possui o formato a seguir:


{
  "classes": [
    {
      "period": "2002.1",
      "rates_by_class": {
        "t1": 0.93,
        "t2": 0.75
      },
      "teachers": [
        "332903",
        "337008"
      ],
      "total": 1.68
    },
    {...},
    {...},
    ]
  "subject_code": "1411167"
}

**Obs:** "t1" e "t2" representam as taxas de sucesso da turma 1 e 2, respectivamente.