### PR TITLE
feat: added /pre_enrollment/all endpoint

### DIFF
--- a/src/main/java/br/edu/ufcg/computacao/eureca/backend/api/http/request/PreEnrollment.java
+++ b/src/main/java/br/edu/ufcg/computacao/eureca/backend/api/http/request/PreEnrollment.java
@@ -48,9 +48,9 @@ public class PreEnrollment {
         }
     }
 
-    @ApiOperation(value = ApiDocumentation.PreEnrollment.GET_PRE_ENROLLMENT)
-    @RequestMapping(value = "/all", method = RequestMethod.GET)
-    public ResponseEntity<ActivesPreEnrollmentResponse> getAllPreEnrollments(
+    @ApiOperation(value = ApiDocumentation.PreEnrollment.GET_ACTIVES_PRE_ENROLLMENTS)
+    @RequestMapping(value = "/actives", method = RequestMethod.GET)
+    public ResponseEntity<ActivesPreEnrollmentResponse> getActivesPreEnrollments(
             @ApiParam(value = ApiDocumentation.Common.COURSE)
             @RequestParam String courseCode,
             @ApiParam(value = ApiDocumentation.Common.CURRICULUM)

--- a/src/main/java/br/edu/ufcg/computacao/eureca/backend/api/http/request/PreEnrollment.java
+++ b/src/main/java/br/edu/ufcg/computacao/eureca/backend/api/http/request/PreEnrollment.java
@@ -1,6 +1,7 @@
 package br.edu.ufcg.computacao.eureca.backend.api.http.request;
 
 import br.edu.ufcg.computacao.eureca.backend.api.http.CommonKeys;
+import br.edu.ufcg.computacao.eureca.backend.api.http.response.ActivesPreEnrollmentResponse;
 import br.edu.ufcg.computacao.eureca.backend.constants.ApiDocumentation;
 import br.edu.ufcg.computacao.eureca.backend.constants.SystemConstants;
 import br.edu.ufcg.computacao.eureca.backend.core.ApplicationFacade;
@@ -14,6 +15,8 @@ import org.apache.log4j.Logger;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Collection;
 
 @CrossOrigin
 @RestController
@@ -45,5 +48,22 @@ public class PreEnrollment {
         }
     }
 
-    // ToDo: criar um endpoint que não recebe a matrícula como parâmetro e calcula a pre-matrícula para todos os alunos ativos
+    @ApiOperation(value = ApiDocumentation.PreEnrollment.GET_PRE_ENROLLMENT)
+    @RequestMapping(value = "/all", method = RequestMethod.GET)
+    public ResponseEntity<ActivesPreEnrollmentResponse> getAllPreEnrollments(
+            @ApiParam(value = ApiDocumentation.Common.COURSE)
+            @RequestParam String courseCode,
+            @ApiParam(value = ApiDocumentation.Common.CURRICULUM)
+            @RequestParam String curriculumCode,
+            @ApiParam(value = ApiDocumentation.Token.AUTHENTICATION_TOKEN)
+            @RequestHeader(value = CommonKeys.AUTHENTICATION_TOKEN_KEY) String token
+    ) throws EurecaException {
+        try {
+            ActivesPreEnrollmentResponse preEnrollments = ApplicationFacade.getInstance().getActivesPreEnrollments(token, courseCode, curriculumCode);
+            return new ResponseEntity<>(preEnrollments, HttpStatus.OK);
+        } catch (EurecaException e) {
+            LOGGER.info(e);
+            throw e;
+        }
+    }
 }

--- a/src/main/java/br/edu/ufcg/computacao/eureca/backend/api/http/response/ActivesPreEnrollmentResponse.java
+++ b/src/main/java/br/edu/ufcg/computacao/eureca/backend/api/http/response/ActivesPreEnrollmentResponse.java
@@ -1,0 +1,40 @@
+package br.edu.ufcg.computacao.eureca.backend.api.http.response;
+
+import br.edu.ufcg.computacao.eureca.backend.core.models.StudentPreEnrollment;
+
+import java.util.Collection;
+
+public class ActivesPreEnrollmentResponse {
+
+    private Collection<StudentPreEnrollment> activesPreEnrollment;
+    private SubjectDemandSummary subjectDemandSummary;
+
+    public ActivesPreEnrollmentResponse(Collection<StudentPreEnrollment> activesPreEnrollment, SubjectDemandSummary subjectDemandSummary) {
+        this.activesPreEnrollment = activesPreEnrollment;
+        this.subjectDemandSummary = subjectDemandSummary;
+    }
+
+    public Collection<StudentPreEnrollment> getActivesPreEnrollment() {
+        return activesPreEnrollment;
+    }
+
+    public void setActivesPreEnrollment(Collection<StudentPreEnrollment> activesPreEnrollment) {
+        this.activesPreEnrollment = activesPreEnrollment;
+    }
+
+    public SubjectDemandSummary getSubjectDemandSummary() {
+        return subjectDemandSummary;
+    }
+
+    public void setSubjectDemandSummary(SubjectDemandSummary subjectDemandSummary) {
+        this.subjectDemandSummary = subjectDemandSummary;
+    }
+
+    @Override
+    public String toString() {
+        return "ActivesPreEnrollmentResponse{" +
+                "activesPreEnrollment=" + activesPreEnrollment +
+                ", subjectDemandSummary=" + subjectDemandSummary +
+                '}';
+    }
+}

--- a/src/main/java/br/edu/ufcg/computacao/eureca/backend/api/http/response/SubjectDemandSummary.java
+++ b/src/main/java/br/edu/ufcg/computacao/eureca/backend/api/http/response/SubjectDemandSummary.java
@@ -1,0 +1,62 @@
+package br.edu.ufcg.computacao.eureca.backend.api.http.response;
+
+import br.edu.ufcg.computacao.eureca.backend.core.models.SubjectDemand;
+
+import java.util.Collection;
+
+public class SubjectDemandSummary {
+
+    private Collection<SubjectDemand> mandatoryDemand;
+    private Collection<SubjectDemand> optionalDemand;
+    private Collection<SubjectDemand> complementaryDemand;
+    private Collection<SubjectDemand> electiveDemand;
+
+    public SubjectDemandSummary(Collection<SubjectDemand> mandatoryDemand, Collection<SubjectDemand> optionalDemand, Collection<SubjectDemand> complementaryDemand, Collection<SubjectDemand> electiveDemand) {
+        this.mandatoryDemand = mandatoryDemand;
+        this.optionalDemand = optionalDemand;
+        this.complementaryDemand = complementaryDemand;
+        this.electiveDemand = electiveDemand;
+    }
+
+    public Collection<SubjectDemand> getMandatoryDemand() {
+        return mandatoryDemand;
+    }
+
+    public void setMandatoryDemand(Collection<SubjectDemand> mandatoryDemand) {
+        this.mandatoryDemand = mandatoryDemand;
+    }
+
+    public Collection<SubjectDemand> getOptionalDemand() {
+        return optionalDemand;
+    }
+
+    public void setOptionalDemand(Collection<SubjectDemand> optionalDemand) {
+        this.optionalDemand = optionalDemand;
+    }
+
+    public Collection<SubjectDemand> getComplementaryDemand() {
+        return complementaryDemand;
+    }
+
+    public void setComplementaryDemand(Collection<SubjectDemand> complementaryDemand) {
+        this.complementaryDemand = complementaryDemand;
+    }
+
+    public Collection<SubjectDemand> getElectiveDemand() {
+        return electiveDemand;
+    }
+
+    public void setElectiveDemand(Collection<SubjectDemand> electiveDemand) {
+        this.electiveDemand = electiveDemand;
+    }
+
+    @Override
+    public String toString() {
+        return "SubjectDemandSummary{" +
+                "mandatoryDemand=" + mandatoryDemand +
+                ", optionalDemand=" + optionalDemand +
+                ", complementaryDemand=" + complementaryDemand +
+                ", electiveDemand=" + electiveDemand +
+                '}';
+    }
+}

--- a/src/main/java/br/edu/ufcg/computacao/eureca/backend/constants/ApiDocumentation.java
+++ b/src/main/java/br/edu/ufcg/computacao/eureca/backend/constants/ApiDocumentation.java
@@ -119,5 +119,6 @@ public class ApiDocumentation {
     public static class PreEnrollment {
         public static final String API = "Pré-matrícula de um aluno.";
         public static final String GET_PRE_ENROLLMENT = "Retorna uma possível pré-matrícula de um aluno específico.";
+        public static final String GET_ACTIVES_PRE_ENROLLMENTS = "Retorna todas as pre-matriculas dos ativos e, juntamente, um sumario com a demanda de cada disciplina.";
     }
 }

--- a/src/main/java/br/edu/ufcg/computacao/eureca/backend/core/ApplicationFacade.java
+++ b/src/main/java/br/edu/ufcg/computacao/eureca/backend/core/ApplicationFacade.java
@@ -143,6 +143,10 @@ public class ApplicationFacade {
         return this.preEnrollmentController.createStudentPreEnrollment(courseCode, curriculumCode, registration);
     }
 
+    public ActivesPreEnrollmentResponse getActivesPreEnrollments(String token, String courseCode, String curriculumCode) throws InvalidParameterException {
+        return this.preEnrollmentController.getActivesPreEnrollmentResponse(courseCode, curriculumCode);
+    }
+
     public StudentsRetentionStatisticsResponse getStudentsRetentionStatistics(String token, String courseCode, String curriculumCode, String from, String to) throws EurecaException {
         authenticateAndAuthorize(token, EurecaOperation.GET_STUDENTS_RETENTION_STATISTICS);
         return this.retentionStatisticsController.getStudentsRetentionStatistics(courseCode, curriculumCode, from, to);

--- a/src/main/java/br/edu/ufcg/computacao/eureca/backend/core/ApplicationFacade.java
+++ b/src/main/java/br/edu/ufcg/computacao/eureca/backend/core/ApplicationFacade.java
@@ -143,7 +143,8 @@ public class ApplicationFacade {
         return this.preEnrollmentController.createStudentPreEnrollment(courseCode, curriculumCode, registration);
     }
 
-    public ActivesPreEnrollmentResponse getActivesPreEnrollments(String token, String courseCode, String curriculumCode) throws InvalidParameterException {
+    public ActivesPreEnrollmentResponse getActivesPreEnrollments(String token, String courseCode, String curriculumCode) throws EurecaException {
+        authenticateAndAuthorize(token, EurecaOperation.GET_ACTIVES_PRE_ENROLLMENTS);
         return this.preEnrollmentController.getActivesPreEnrollmentResponse(courseCode, curriculumCode);
     }
 

--- a/src/main/java/br/edu/ufcg/computacao/eureca/backend/core/controllers/PreEnrollmentController.java
+++ b/src/main/java/br/edu/ufcg/computacao/eureca/backend/core/controllers/PreEnrollmentController.java
@@ -1,13 +1,19 @@
 package br.edu.ufcg.computacao.eureca.backend.core.controllers;
 
+import br.edu.ufcg.computacao.eureca.backend.api.http.response.ActivesPreEnrollmentResponse;
+import br.edu.ufcg.computacao.eureca.backend.constants.SystemConstants;
 import br.edu.ufcg.computacao.eureca.backend.core.dao.DataAccessFacade;
 import br.edu.ufcg.computacao.eureca.backend.core.models.*;
 import br.edu.ufcg.computacao.eureca.backend.core.holders.DataAccessFacadeHolder;
+import br.edu.ufcg.computacao.eureca.common.exceptions.EurecaException;
 import br.edu.ufcg.computacao.eureca.common.exceptions.InvalidParameterException;
+import org.apache.log4j.Logger;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 public class PreEnrollmentController {
+    private static final Logger LOGGER = Logger.getLogger(PreEnrollmentController.class);
 
     private DataAccessFacade dataAccessFacade;
 
@@ -16,51 +22,10 @@ public class PreEnrollmentController {
     }
 
     public StudentPreEnrollment createStudentPreEnrollment(String courseCode, String curriculumCode, String studentRegistration) throws InvalidParameterException {
-        Curriculum curriculum = this.dataAccessFacade.getCurriculum(courseCode, curriculumCode);
-        StudentCurriculumProgress progress = this.dataAccessFacade.getStudentCurriculumProgress(studentRegistration);
-        // ToDo: mudar essa lógica para considerar o número ideal de créditos por tipo
-        int idealNumberOfCredits = getIdealNumberOfCredits(curriculum, progress);
-        int actualTerm = progress.getCompletedTerms() + (progress.getEnrolledCredits() > 0 ? 2 : 1);
-        StudentPreEnrollment studentPreEnrollment = new StudentPreEnrollment(studentRegistration, actualTerm, idealNumberOfCredits);
-
-        List<Subject> availableMandatorySubjects = this.dataAccessFacade.getMandatorySubjectsAvailableForEnrollment(courseCode, curriculumCode, studentRegistration);
-        List<Subject> availableComplementarySubjects = this.dataAccessFacade.getComplementarySubjectsAvailableForEnrollment(courseCode, curriculumCode, studentRegistration);
-        List<Subject> availableElectiveSubjects = this.dataAccessFacade.getElectiveSubjectsAvailableForEnrollment(courseCode, curriculumCode, studentRegistration);
-        List<Subject> availableOptionalSubjects = this.dataAccessFacade.getOptionalSubjectsAvailableForEnrollment(courseCode, curriculumCode, studentRegistration);
-
-        // ToDo: mudar essa lógica para matricular no número ideal de créditos por tipo (sem considerar co-requisitos, por enquanto)
-        while(!studentPreEnrollment.isFull()) {
-            for (Subject s : availableMandatorySubjects)
-                studentPreEnrollment.addSubject(s);
-
-            if (!studentPreEnrollment.isFull()) {
-                for (Subject s : availableOptionalSubjects)
-                    studentPreEnrollment.addSubject(s);
-            }
-
-            if (!studentPreEnrollment.isFull()) {
-                for (Subject s : availableComplementarySubjects)
-                    studentPreEnrollment.addSubject(s);
-            }
-
-            if (!studentPreEnrollment.isFull()) {
-                for (Subject s : availableElectiveSubjects)
-                    studentPreEnrollment.addSubject(s);
-            }
-
-            if (studentPreEnrollment.getSubjects().isEmpty()) break;
-        }
-
-        return studentPreEnrollment;
+        return this.dataAccessFacade.getStudentPreEnrollment(courseCode, curriculumCode, studentRegistration);
     }
 
-    private int getIdealNumberOfCredits(Curriculum curriculum, StudentCurriculumProgress progress) {
-        // ToDo: calcular nextTerm levando em consideração o número de créditos integralizados e
-        // o campo expectedMinAccumulatedCreditsList de currículo
-        int nextTerm = progress.getCompletedTerms() + (progress.getEnrolledCredits() > 0 ? 2 : 1);
-        int idealMandatoryCredits = curriculum.getIdealMandatoryCredits(nextTerm);
-        int idealOptionalCredits = curriculum.getIdealOptionalCredits(nextTerm);
-        int idealComplementaryCredits = curriculum.getIdealComplementaryCredits(nextTerm);
-        return idealMandatoryCredits + idealOptionalCredits + idealComplementaryCredits;
+    public ActivesPreEnrollmentResponse getActivesPreEnrollmentResponse(String courseCode, String curriculumCode) throws InvalidParameterException  {
+        return this.dataAccessFacade.getActivesPreEnrollment(courseCode, curriculumCode);
     }
 }

--- a/src/main/java/br/edu/ufcg/computacao/eureca/backend/core/dao/DataAccessFacade.java
+++ b/src/main/java/br/edu/ufcg/computacao/eureca/backend/core/dao/DataAccessFacade.java
@@ -1,11 +1,7 @@
 package br.edu.ufcg.computacao.eureca.backend.core.dao;
 
 import br.edu.ufcg.computacao.eureca.backend.api.http.response.*;
-import br.edu.ufcg.computacao.eureca.backend.core.models.StudentCurriculumProgress;
-import br.edu.ufcg.computacao.eureca.backend.core.models.Curriculum;
-import br.edu.ufcg.computacao.eureca.backend.core.models.Student;
-import br.edu.ufcg.computacao.eureca.backend.core.models.Subject;
-import br.edu.ufcg.computacao.eureca.backend.core.models.SubjectType;
+import br.edu.ufcg.computacao.eureca.backend.core.models.*;
 import br.edu.ufcg.computacao.eureca.common.exceptions.InvalidParameterException;
 
 import java.util.Collection;
@@ -62,4 +58,8 @@ public interface DataAccessFacade {
     Map<String, TeachersStatisticsSummary> getTeachersPerAcademicUnit(String courseCode, String curriculumCode, String from, String to) throws InvalidParameterException;
 
     StudentCurriculumProgress getStudentCurriculumProgress(String studentRegistration) throws InvalidParameterException;
+
+    StudentPreEnrollment getStudentPreEnrollment(String courseCode, String curriculumCode, String studentRegistration) throws InvalidParameterException;
+
+    ActivesPreEnrollmentResponse getActivesPreEnrollment(String courseCode, String curriculumCode) throws InvalidParameterException;
 }

--- a/src/main/java/br/edu/ufcg/computacao/eureca/backend/core/dao/scsvfiles/ScsvFilesDataAccessFacade.java
+++ b/src/main/java/br/edu/ufcg/computacao/eureca/backend/core/dao/scsvfiles/ScsvFilesDataAccessFacade.java
@@ -464,7 +464,7 @@ public class ScsvFilesDataAccessFacade implements DataAccessFacade {
             if (minAccumulatedCredits >= accumulatedCredits)
                 return i;
         }
-        return 8;
+        return 8; // o que fazer quando itera sobre a lista de créditos esperados e não 'casar' com nenhum? (está retornando o ultimo periodo)
     }
 
     private Subject getSubject(SubjectKey subjectKey) {

--- a/src/main/java/br/edu/ufcg/computacao/eureca/backend/core/dao/scsvfiles/ScsvFilesDataAccessFacade.java
+++ b/src/main/java/br/edu/ufcg/computacao/eureca/backend/core/dao/scsvfiles/ScsvFilesDataAccessFacade.java
@@ -448,8 +448,6 @@ public class ScsvFilesDataAccessFacade implements DataAccessFacade {
     }
 
     private int getIdealNumberOfCredits(Curriculum curriculum, StudentCurriculumProgress progress) {
-        // ToDo: calcular nextTerm levando em consideração o número de créditos integralizados e
-        // o campo expectedMinAccumulatedCreditsList de currículo
         int nextTerm = this.getNextTerm(curriculum, progress);
         int idealMandatoryCredits = curriculum.getIdealMandatoryCredits(nextTerm);
         int idealOptionalCredits = curriculum.getIdealOptionalCredits(nextTerm);

--- a/src/main/java/br/edu/ufcg/computacao/eureca/backend/core/models/EurecaOperation.java
+++ b/src/main/java/br/edu/ufcg/computacao/eureca/backend/core/models/EurecaOperation.java
@@ -25,7 +25,8 @@ public enum EurecaOperation {
     GET_SUBJECT_ENROLLMENTS_STATISTICS_SUMMARY("getSubjectEnrollmentsStatisticsSummary"),
     GET_CURRICULUM_CODES("getCurriculumCodes"),
     GET_PROFILE("getProfile"),
-    CREATE_PRE_ENROLLMENT("createPreEnrollment");
+    CREATE_PRE_ENROLLMENT("createPreEnrollment"),
+    GET_ACTIVES_PRE_ENROLLMENTS("getActivesPreEnrollments");
 
     private String value;
 

--- a/src/main/java/br/edu/ufcg/computacao/eureca/backend/core/models/StudentCurriculumProgress.java
+++ b/src/main/java/br/edu/ufcg/computacao/eureca/backend/core/models/StudentCurriculumProgress.java
@@ -43,6 +43,10 @@ public class StudentCurriculumProgress {
         return completedMandatoryCredits;
     }
 
+    public int getCompletedCredits() {
+        return completedComplementaryCredits + completedMandatoryCredits + completedOptionalCredits;
+    }
+
     public void setCompletedMandatoryCredits(int completedMandatoryCredits) {
         this.completedMandatoryCredits = completedMandatoryCredits;
     }

--- a/src/main/java/br/edu/ufcg/computacao/eureca/backend/core/models/Subject.java
+++ b/src/main/java/br/edu/ufcg/computacao/eureca/backend/core/models/Subject.java
@@ -1,6 +1,7 @@
 package br.edu.ufcg.computacao.eureca.backend.core.models;
 
 import java.util.Collection;
+import java.util.Objects;
 
 public class Subject {
     private String courseCode;
@@ -109,6 +110,19 @@ public class Subject {
 
     public Collection<String> getPreRequirementsList() {
         return preRequirementsList;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Subject subject = (Subject) o;
+        return courseCode.equals(subject.courseCode) && curriculumCode.equals(subject.curriculumCode) && subjectCode.equals(subject.subjectCode);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(courseCode, curriculumCode, subjectCode);
     }
 
     @Override

--- a/src/main/java/br/edu/ufcg/computacao/eureca/backend/core/models/SubjectDemand.java
+++ b/src/main/java/br/edu/ufcg/computacao/eureca/backend/core/models/SubjectDemand.java
@@ -1,0 +1,56 @@
+package br.edu.ufcg.computacao.eureca.backend.core.models;
+
+import java.util.Map;
+
+public class SubjectDemand {
+
+    private String subjectCode;
+    private String subjectName;
+    private Map<Integer, Integer> demandByTerm;
+    private int totalDemand;
+
+    public SubjectDemand(Subject subject, Map<Integer, Integer> demandByTerm) {
+        this.subjectCode = subject.getSubjectCode();
+        this.subjectName = subject.getName();
+        this.demandByTerm = demandByTerm;
+        this.calculateTotalDemand();
+    }
+
+    private void calculateTotalDemand() {
+        int totalDemand = 0;
+        for (Integer demand : this.demandByTerm.values()) {
+            totalDemand += demand;
+        }
+        this.totalDemand = totalDemand;
+    }
+
+    public String getSubjectCode() {
+        return subjectCode;
+    }
+
+    public String getSubjectName() {
+        return subjectName;
+    }
+
+    public Map<Integer, Integer> getDemandByTerm() {
+        return demandByTerm;
+    }
+
+    public void setDemandByTerm(Map<Integer, Integer> demandByTerm) {
+        this.demandByTerm = demandByTerm;
+    }
+
+    public int getTotalDemand() {
+        return totalDemand;
+    }
+
+    @Override
+    public String toString() {
+        return "SubjectDemand{" +
+                "subjectCode='" + subjectCode + '\'' +
+                ", subjectName='" + subjectName + '\'' +
+                ", demandByTerm=" + demandByTerm +
+                ", totalDemand=" + totalDemand +
+                '}';
+    }
+}

--- a/src/main/java/br/edu/ufcg/computacao/eureca/backend/core/models/SubjectType.java
+++ b/src/main/java/br/edu/ufcg/computacao/eureca/backend/core/models/SubjectType.java
@@ -15,4 +15,12 @@ public enum SubjectType {
     public String getValue() {
         return this.value;
     }
+
+    public static SubjectType toEnum(String value) {
+        for (SubjectType subjectType : SubjectType.values()) {
+            if (subjectType.getValue().equals(value))
+                return subjectType;
+        }
+        return null;
+    }
 }


### PR DESCRIPTION
feat: included SubjectDemandSummaryResponse
refactor: moved StudentPreEnrollment creation logic to DataAccessFacade
fix: calculating nextTerm by student accumulated credits

PS: o campo Map<Integer, Integer> demandByTerm, em SubjectDemand, refere-se à demanda por período. Isto é, há 'n' alunos do período 'x' que possuem essa disciplina na pré matrícula

PS2: optei por deixar só o código da disciplina na resposta da demanda, pois iria ficaria bastante poluída, visto que o vetor de pré matrículas já é bem grande